### PR TITLE
INT: Update angular2-hotkeys peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "rxjs": ">=6.5.0",
         "@jscrpt/common": ">=1.1.0",
         "numeral": "~2.0.6",
-        "angular2-hotkeys": "~2.1.0",
+        "angular2-hotkeys": "~2.2.0",
         "store": "~2.0.12",
         "structured-log": "~0.2.0",
         "moment": "^2.24.0",


### PR DESCRIPTION
Since angular2-hotkeys patch versions usually correspond with angular major version i would keep tilde and bump minor version this time.